### PR TITLE
Rename company references to Lag Daddy Golf Co

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Lag Daddy Golf Apparel Website</title>
+    <title>Lag Daddy Golf Co Website</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -26,7 +26,7 @@ export default function Header() {
           </button>
 
           <Link to="/" className="text-3xl md:text-4xl font-light tracking-[0.3em] uppercase hover:text-neutral-300 transition-colors">
-            Lag Daddy
+            Lag Daddy Golf Co
           </Link>
 
           <div className="w-12" />

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -104,10 +104,10 @@ export default function Home() {
       <footer className="bg-black py-12 px-6">
         <div className="container mx-auto text-center text-white">
           <h3 className="text-2xl font-light tracking-[0.3em] uppercase mb-4">
-            Lag Daddy
+            Lag Daddy Golf Co
           </h3>
           <p className="text-neutral-500 font-light">
-            © 2025 Lag Daddy Golf Apparel. All rights reserved.
+            © 2025 Lag Daddy Golf Co. All rights reserved.
           </p>
         </div>
       </footer>

--- a/src/components/ReserveBay.tsx
+++ b/src/components/ReserveBay.tsx
@@ -48,7 +48,7 @@ export default function ReserveBay() {
             Reserve a Bay
           </h1>
           <p className="text-neutral-400 font-light text-lg md:text-xl max-w-2xl mx-auto">
-            Choose your preferred Lag Daddy Lounge location and enter your address to
+            Choose your preferred Lag Daddy Golf Co Lounge location and enter your address to
             find the closest available bay. We&apos;ll match you with premium hitting bays
             outfitted with the latest tech and tailored service.
           </p>

--- a/src/data/products.ts
+++ b/src/data/products.ts
@@ -30,11 +30,11 @@ export const products: Product[] = [
     price: 79.99,
     image: '/Gemini_Generated_Image_9pmrtr9pmrtr9pmr.png',
     category: 'men',
-    description: 'Protect your most valuable club with our premium leather driver headcover. Features the iconic Lag Daddy logo and superior padding.',
+    description: 'Protect your most valuable club with our premium leather driver headcover. Features the iconic Lag Daddy Golf Co logo and superior padding.',
     features: [
       'Premium synthetic leather construction',
       'Plush interior lining',
-      'Embroidered Lag Daddy logo',
+      'Embroidered Lag Daddy Golf Co logo',
       'Easy on/off magnetic closure',
       'Water-resistant exterior'
     ]


### PR DESCRIPTION
## Summary
- update the site title and navigation branding to reference Lag Daddy Golf Co
- refresh footer and marketing copy to reflect the new company name
- adjust product descriptions to mention the Lag Daddy Golf Co logo

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df45c5959c832194e3fe7e1b3860df