### PR TITLE
Add Denver option and bay results flow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import Home from './components/Home';
 import MensCollection from './components/MensCollection';
 import ProductDetail from './components/ProductDetail';
 import ReserveBay from './components/ReserveBay';
+import ReserveBayResults from './components/ReserveBayResults';
 
 function App() {
   return (
@@ -17,6 +18,7 @@ function App() {
           <Route path="/collection/kids" element={<div className="pt-32 text-center">Kids' Collection Coming Soon</div>} />
           <Route path="/product/:id" element={<ProductDetail />} />
           <Route path="/reserve" element={<ReserveBay />} />
+          <Route path="/reserve/results" element={<ReserveBayResults />} />
         </Routes>
       </div>
     </Router>

--- a/src/components/ReserveBay.tsx
+++ b/src/components/ReserveBay.tsx
@@ -1,43 +1,30 @@
 import { useState } from 'react';
-
-const bayLocations = [
-  {
-    city: 'Scottsdale, AZ',
-    address: '15200 N Hayden Rd',
-    bays: 18,
-  },
-  {
-    city: 'Austin, TX',
-    address: '3600 Ranch Rd 620 S',
-    bays: 24,
-  },
-  {
-    city: 'Nashville, TN',
-    address: '1200 Broadway Pl',
-    bays: 20,
-  },
-  {
-    city: 'Orlando, FL',
-    address: '4500 International Dr',
-    bays: 16,
-  },
-];
+import { useNavigate } from 'react-router-dom';
+import { bayLocations } from '../data/bayLocations';
 
 export default function ReserveBay() {
+  const navigate = useNavigate();
   const [selectedLocation, setSelectedLocation] = useState(bayLocations[0]);
   const [address, setAddress] = useState('');
-  const [searchMessage, setSearchMessage] = useState('');
+  const [errorMessage, setErrorMessage] = useState('');
 
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (!address.trim()) {
-      setSearchMessage('Please enter an address to find a bay near you.');
+    const trimmedAddress = address.trim();
+
+    if (!trimmedAddress) {
+      setErrorMessage('Please enter an address to find a bay near you.');
       return;
     }
 
-    setSearchMessage(
-      `We’ll show you bays near ${address.trim()} in ${selectedLocation.city}.`
-    );
+    setErrorMessage('');
+
+    navigate('/reserve/results', {
+      state: {
+        address: trimmedAddress,
+        locationId: selectedLocation.id,
+      },
+    });
   };
 
   return (
@@ -62,9 +49,9 @@ export default function ReserveBay() {
               </label>
               <select
                 id="location"
-                value={selectedLocation.city}
+                value={selectedLocation.id}
                 onChange={(event) => {
-                  const location = bayLocations.find((option) => option.city === event.target.value);
+                  const location = bayLocations.find((option) => option.id === event.target.value);
                   if (location) {
                     setSelectedLocation(location);
                   }
@@ -72,7 +59,7 @@ export default function ReserveBay() {
                 className="w-full bg-black/60 border border-neutral-700 rounded-full px-6 py-4 text-lg font-light focus:outline-none focus:ring-2 focus:ring-white/40"
               >
                 {bayLocations.map((location) => (
-                  <option key={location.city} value={location.city}>
+                  <option key={location.id} value={location.id}>
                     {location.city} — {location.bays} bays
                   </option>
                 ))}
@@ -91,9 +78,17 @@ export default function ReserveBay() {
                 type="text"
                 placeholder="Enter your street, city, or zip"
                 value={address}
-                onChange={(event) => setAddress(event.target.value)}
+                onChange={(event) => {
+                  setAddress(event.target.value);
+                  if (errorMessage) {
+                    setErrorMessage('');
+                  }
+                }}
                 className="w-full bg-black/60 border border-neutral-700 rounded-full px-6 py-4 text-lg font-light placeholder:text-neutral-600 focus:outline-none focus:ring-2 focus:ring-white/40"
               />
+              {errorMessage && (
+                <p className="mt-3 text-sm text-red-400 font-light">{errorMessage}</p>
+              )}
             </div>
 
             <button
@@ -103,12 +98,6 @@ export default function ReserveBay() {
               Find Bays Nearby
             </button>
           </form>
-
-          {searchMessage && (
-            <div className="mt-10 rounded-2xl border border-white/10 bg-white/5 px-6 py-5 text-neutral-200 font-light">
-              {searchMessage}
-            </div>
-          )}
         </section>
       </div>
     </main>

--- a/src/components/ReserveBayResults.tsx
+++ b/src/components/ReserveBayResults.tsx
@@ -1,0 +1,100 @@
+import { useEffect } from 'react';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { bayLocations } from '../data/bayLocations';
+
+type LocationState = {
+  address: string;
+  locationId: string;
+};
+
+export default function ReserveBayResults() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const state = location.state as LocationState | null;
+
+  useEffect(() => {
+    if (!state) {
+      navigate('/reserve', { replace: true });
+    }
+  }, [navigate, state]);
+
+  if (!state) {
+    return null;
+  }
+
+  const selectedLocation = bayLocations.find((option) => option.id === state.locationId);
+
+  if (!selectedLocation) {
+    return (
+      <main className="pt-32 pb-24 px-6 bg-neutral-950 min-h-screen text-white">
+        <div className="container mx-auto max-w-4xl text-center space-y-6">
+          <h1 className="text-4xl md:text-5xl font-light uppercase tracking-[0.3em]">Location Not Found</h1>
+          <p className="text-neutral-400 font-light text-lg">
+            We couldn&apos;t find that lounge. Please start a new search to explore available bays.
+          </p>
+          <Link
+            to="/reserve"
+            className="inline-flex items-center justify-center px-10 py-4 rounded-full bg-white text-black uppercase tracking-[0.3em] font-light hover:bg-neutral-200 transition-colors duration-300"
+          >
+            Start a New Search
+          </Link>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="pt-32 pb-24 px-6 bg-neutral-950 min-h-screen text-white">
+      <div className="container mx-auto max-w-5xl">
+        <div className="mb-12 text-center space-y-4">
+          <p className="text-sm uppercase tracking-[0.4em] text-neutral-500">Bays Near You</p>
+          <h1 className="text-4xl md:text-5xl font-light uppercase tracking-[0.3em]">
+            {selectedLocation.city}
+          </h1>
+          <p className="text-neutral-400 font-light text-lg md:text-xl">
+            Showing premium bays within a quick ride of <span className="text-white">{state.address}</span>. Every suite
+            includes concierge service, elite tech, and a vibe tailored to your group.
+          </p>
+        </div>
+
+        <section className="bg-neutral-900/70 border border-neutral-800 rounded-3xl p-8 md:p-12 backdrop-blur space-y-10">
+          <header className="flex flex-col md:flex-row md:items-center md:justify-between gap-6">
+            <div>
+              <h2 className="text-2xl font-light text-white">{selectedLocation.address}</h2>
+              <p className="text-neutral-400 font-light">{selectedLocation.bays} championship bays available</p>
+            </div>
+            <Link
+              to="/reserve"
+              className="inline-flex items-center justify-center px-10 py-4 rounded-full bg-white text-black uppercase tracking-[0.3em] font-light hover:bg-neutral-200 transition-colors duration-300"
+            >
+              Adjust Search
+            </Link>
+          </header>
+
+          <div className="grid gap-6 md:grid-cols-2">
+            {selectedLocation.bayDetails.map((bay) => (
+              <article
+                key={bay.id}
+                className="rounded-3xl border border-white/10 bg-white/5 p-6 md:p-8 flex flex-col gap-4 text-neutral-200"
+              >
+                <div>
+                  <h3 className="text-xl font-light text-white">{bay.id}</h3>
+                  <p className="text-sm uppercase tracking-[0.3em] text-neutral-500">{bay.distance} away</p>
+                </div>
+                <p className="text-sm text-lime-300 tracking-[0.2em] uppercase">{bay.availability}</p>
+                <ul className="space-y-2 text-sm text-neutral-300">
+                  {bay.features.map((feature) => (
+                    <li key={feature} className="flex items-start gap-3">
+                      <span className="mt-0.5 h-2 w-2 rounded-full bg-lime-400" aria-hidden="true" />
+                      <span className="font-light">{feature}</span>
+                    </li>
+                  ))}
+                </ul>
+              </article>
+            ))}
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/data/bayLocations.ts
+++ b/src/data/bayLocations.ts
@@ -1,0 +1,207 @@
+export type BayDetail = {
+  id: string;
+  distance: string;
+  availability: string;
+  features: string[];
+};
+
+export type BayLocation = {
+  id: string;
+  city: string;
+  address: string;
+  bays: number;
+  bayDetails: BayDetail[];
+};
+
+export const bayLocations: BayLocation[] = [
+  {
+    id: 'scottsdale',
+    city: 'Scottsdale, AZ',
+    address: '15200 N Hayden Rd',
+    bays: 18,
+    bayDetails: [
+      {
+        id: 'Scottsdale Elite Bay 4',
+        distance: '0.6 miles',
+        availability: 'Prime-time spots open tonight',
+        features: [
+          'Toptracer Range tracking',
+          'Climate-controlled private suite',
+          'Dedicated host service',
+        ],
+      },
+      {
+        id: 'Scottsdale Signature Bay 9',
+        distance: '1.1 miles',
+        availability: 'Early afternoon sessions available',
+        features: [
+          'Complimentary club fittings',
+          'Lounge seating for 6 guests',
+          'Unlimited practice balls',
+        ],
+      },
+      {
+        id: 'Scottsdale Social Bay 12',
+        distance: '1.8 miles',
+        availability: 'Weekend reservations filling fast',
+        features: [
+          'VIP bar access',
+          'Panoramic mountain views',
+          'Short-game practice area',
+        ],
+      },
+    ],
+  },
+  {
+    id: 'austin',
+    city: 'Austin, TX',
+    address: '3600 Ranch Rd 620 S',
+    bays: 24,
+    bayDetails: [
+      {
+        id: 'Austin Pro Bay 2',
+        distance: '0.4 miles',
+        availability: 'Morning tee times available',
+        features: [
+          'TrackMan combine testing',
+          'Complimentary cold brew station',
+          'On-site club doctor',
+        ],
+      },
+      {
+        id: 'Austin Hill Country Bay 7',
+        distance: '1.3 miles',
+        availability: 'Evening sessions wide open',
+        features: [
+          'Sunset view terrace',
+          'Acoustic live sessions nightly',
+          'Precision short game targets',
+        ],
+      },
+      {
+        id: 'Austin Executive Bay 15',
+        distance: '2.1 miles',
+        availability: 'Corporate packages available',
+        features: [
+          'Private concierge team',
+          'Chef-curated tasting menu',
+          'High-speed ball data exports',
+        ],
+      },
+    ],
+  },
+  {
+    id: 'nashville',
+    city: 'Nashville, TN',
+    address: '1200 Broadway Pl',
+    bays: 20,
+    bayDetails: [
+      {
+        id: 'Nashville Skyline Bay 1',
+        distance: '0.7 miles',
+        availability: 'Happy hour tee times available',
+        features: [
+          'Music City playlist concierge',
+          'Private bourbon lockers',
+          'Tour-level analytics',
+        ],
+      },
+      {
+        id: 'Nashville Stage Bay 8',
+        distance: '1.5 miles',
+        availability: 'Weeknight sessions open',
+        features: [
+          'Live songwriter showcases',
+          'Premium leather seating',
+          'Enhanced short-game simulator',
+        ],
+      },
+      {
+        id: 'Nashville Loft Bay 14',
+        distance: '2.4 miles',
+        availability: 'Limited availability this weekend',
+        features: [
+          'Rooftop lounge access',
+          'Mixology-led craft cocktails',
+          'Pro tips from local coaches',
+        ],
+      },
+    ],
+  },
+  {
+    id: 'orlando',
+    city: 'Orlando, FL',
+    address: '4500 International Dr',
+    bays: 16,
+    bayDetails: [
+      {
+        id: 'Orlando Resort Bay 3',
+        distance: '0.9 miles',
+        availability: 'Midday sessions open',
+        features: [
+          'Resort shuttle pickup',
+          'Kid-friendly swing analysis',
+          'Cooling mist canopy',
+        ],
+      },
+      {
+        id: 'Orlando Champions Bay 6',
+        distance: '1.6 miles',
+        availability: 'Evening availability limited',
+        features: [
+          'Championship course simulations',
+          'Priority access to putting lab',
+          'Smoothie and juice bar',
+        ],
+      },
+      {
+        id: 'Orlando Night Lights Bay 11',
+        distance: '2.2 miles',
+        availability: 'Late-night experiences open',
+        features: [
+          'LED night target range',
+          'Live DJ sets',
+          'VIP cabana seating',
+        ],
+      },
+    ],
+  },
+  {
+    id: 'denver',
+    city: 'Denver, CO',
+    address: '1800 Wazee St',
+    bays: 22,
+    bayDetails: [
+      {
+        id: 'Denver Mile High Bay 5',
+        distance: '0.5 miles',
+        availability: 'Afternoon reservations open',
+        features: [
+          'High-altitude ball flight tuning',
+          'Heated terrace lounge',
+          'Colorado craft beverage pairings',
+        ],
+      },
+      {
+        id: 'Denver Skyline Bay 10',
+        distance: '1.2 miles',
+        availability: 'Evening sessions available',
+        features: [
+          'Rocky Mountain sunset views',
+          'Premium sound experience',
+          'On-demand swing coaching',
+        ],
+      },
+      {
+        id: 'Denver Urban Bay 17',
+        distance: '2.0 miles',
+        availability: 'Weekend tee times remaining',
+        features: [
+          'Local chef tasting menu',
+          'Cold-weather gear lockers',
+          'Advanced shot tracer wall',
+        ],
+      },
+    ],
+  },
+];


### PR DESCRIPTION
## Summary
- add a shared bay location dataset including the new Denver lounge
- update the Reserve a Bay form to validate addresses and redirect to results
- create a results page that lists nearby bay options and wire it into the router

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df486e45cc8321b620077af72d21ca