### PR TITLE
Use local hero background video

### DIFF
--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -93,13 +93,17 @@ export default function Home() {
         </video>
 
         <div className="relative z-20 h-full flex flex-col items-center justify-center text-center px-6">
-          <div className="relative inline-block mx-auto mb-6 px-8 py-6">
-            <img
-              src="https://storage.googleapis.com/agent-bench-assets/kt4Q6FhKiP98o2zS7/2f81c8cf-7413-468d-8fa8-0088469cd756.png"
-              alt="Golf ball rolling on green"
-              className="absolute inset-0 h-full w-full object-cover opacity-50 rounded-3xl"
+          <div className="relative inline-block mx-auto mb-6 px-8 py-6 overflow-hidden rounded-3xl">
+            <video
+              autoPlay
+              loop
+              muted
+              playsInline
+              className="absolute inset-0 h-full w-full object-cover opacity-50"
               aria-hidden="true"
-            />
+            >
+              <source src="/Golf%20Video.mp4" type="video/mp4" />
+            </video>
             <div className="absolute inset-0 rounded-3xl bg-black/40" aria-hidden="true" />
             <h2 className="relative text-5xl md:text-7xl font-light tracking-[0.2em] uppercase">
               Perfecting


### PR DESCRIPTION
## Summary
- replace the hero heading background image with the looping Golf Video.mp4 asset from the public directory
- ensure the heading container clips the video and keeps the dark overlay for text readability

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dff6e203788321b02473fdae6f6eaa