### PR TITLE
Add Strapi dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "vite-react-typescript-starter",
       "version": "0.0.0",
       "dependencies": {
+        "@strapi/strapi": "^4.25.4",
         "@supabase/supabase-js": "^2.57.4",
         "lucide-react": "^0.344.0",
         "react": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "typecheck": "tsc --noEmit -p tsconfig.app.json"
   },
   "dependencies": {
+    "@strapi/strapi": "^4.25.4",
     "@supabase/supabase-js": "^2.57.4",
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",


### PR DESCRIPTION
## Summary
- add the `@strapi/strapi` package as an application dependency
- sync the package lockfile to reference the new dependency

## Testing
- not run (dependency installation is blocked behind the provided npm proxy)


------
https://chatgpt.com/codex/tasks/task_e_68e7e79391ec832191734158370a1eaf