### PR TITLE
Add homepage CTA linking to Strapi golf page

### DIFF
--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -127,6 +127,12 @@ export default function Home() {
             >
               Reserve a Bay
             </Link>
+            <a
+              href="https://strapi.lagdaddy.com/golf1"
+              className="px-12 py-4 bg-emerald-400 text-black uppercase tracking-widest font-light hover:bg-emerald-300 transition-colors duration-300"
+            >
+              Connect Here
+            </a>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- add a Connect Here call-to-action button to the homepage hero
- link the new button to the Strapi Lagdaddy golf1 page for quick access

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e7f04eb45c832180dad2bff25acb09