### PR TITLE
Fetch product data from Contentful for PDPs

### DIFF
--- a/src/components/MensCollection.tsx
+++ b/src/components/MensCollection.tsx
@@ -1,11 +1,16 @@
 import { useMemo } from 'react';
 import { Link } from 'react-router-dom';
-import { getProductsByCategory } from '../data/products';
+import { useProducts } from '../hooks/useProducts';
 import StructuredData from './StructuredData';
 import { SITE_URL, usePageMetadata } from '../hooks/usePageMetadata';
 
 export default function MensCollection() {
-  const mensProducts = getProductsByCategory('men');
+  const { products, isLoading, error } = useProducts();
+
+  const mensProducts = useMemo(
+    () => products.filter((product) => product.category === 'men'),
+    [products]
+  );
 
   usePageMetadata({
     title: "Men's Golf Collection | Lag Daddy Golf Co",
@@ -54,32 +59,48 @@ export default function MensCollection() {
           </p>
         </div>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-          {mensProducts.map((product) => (
-            <Link
-              key={product.id}
-              to={`/product/${product.id}`}
-              className="group"
-            >
-              <div className="relative overflow-hidden bg-neutral-800 aspect-square mb-4">
-                <img
-                  src={product.image}
-                  alt={product.name}
-                  className="w-full h-full object-cover group-hover:scale-110 transition-transform duration-700"
-                />
-                <div className="absolute inset-0 bg-black/0 group-hover:bg-black/20 transition-colors duration-300" />
-              </div>
-              <div className="space-y-2">
-                <h3 className="text-2xl font-light tracking-wide group-hover:text-neutral-300 transition-colors">
-                  {product.name}
-                </h3>
-                <p className="text-xl font-light text-neutral-400">
-                  ${product.price.toFixed(2)}
-                </p>
-              </div>
-            </Link>
-          ))}
-        </div>
+        {isLoading ? (
+          <div className="text-neutral-400 font-light">Loading products...</div>
+        ) : error ? (
+          <div className="text-rose-400 font-light">
+            Unable to load products from Contentful. Displaying available inventory.
+          </div>
+        ) : null}
+
+        {mensProducts.length > 0 ? (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 mt-8">
+            {mensProducts.map((product) => (
+              <Link
+                key={product.id}
+                to={`/product/${product.id}`}
+                className="group"
+              >
+                <div className="relative overflow-hidden bg-neutral-800 aspect-square mb-4">
+                  <img
+                    src={product.image}
+                    alt={product.name}
+                    className="w-full h-full object-cover group-hover:scale-110 transition-transform duration-700"
+                  />
+                  <div className="absolute inset-0 bg-black/0 group-hover:bg-black/20 transition-colors duration-300" />
+                </div>
+                <div className="space-y-2">
+                  <h3 className="text-2xl font-light tracking-wide group-hover:text-neutral-300 transition-colors">
+                    {product.name}
+                  </h3>
+                  <p className="text-xl font-light text-neutral-400">
+                    ${product.price.toFixed(2)}
+                  </p>
+                </div>
+              </Link>
+            ))}
+          </div>
+        ) : (
+          !isLoading && (
+            <div className="text-neutral-400 font-light mt-8">
+              No products available in this collection right now.
+            </div>
+          )
+        )}
       </div>
 
       <StructuredData id="mens-breadcrumbs" data={breadcrumbStructuredData} />

--- a/src/components/ProductDetail.tsx
+++ b/src/components/ProductDetail.tsx
@@ -1,13 +1,13 @@
 import { useState, useMemo } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { ArrowLeft, ShoppingCart, Check } from 'lucide-react';
-import { getProductById } from '../data/products';
 import StructuredData from './StructuredData';
 import { SITE_URL, usePageMetadata } from '../hooks/usePageMetadata';
+import { useProductById } from '../hooks/useProducts';
 
 export default function ProductDetail() {
   const { id } = useParams<{ id: string }>();
-  const product = id ? getProductById(id) : undefined;
+  const { product, isLoading, error } = useProductById(id);
   const [addedToCart, setAddedToCart] = useState(false);
 
   const productTitle = product
@@ -88,6 +88,19 @@ export default function ProductDetail() {
     ],
   }), [product]);
 
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-neutral-900 text-white pt-32 pb-24 px-6">
+        <div className="container mx-auto text-center">
+          <h1 className="text-4xl font-light mb-4">Loading product...</h1>
+          <p className="text-neutral-400 font-light">
+            Fetching the latest details from Contentful.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
   if (!product) {
     return (
       <div className="min-h-screen bg-neutral-900 text-white pt-32 pb-24 px-6">
@@ -120,6 +133,12 @@ export default function ProductDetail() {
           <ArrowLeft size={20} />
           Back to Men's Collection
         </Link>
+
+        {error && (
+          <div className="mb-8 text-rose-400 font-light">
+            Unable to load live product data from Contentful. Displaying available information.
+          </div>
+        )}
 
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-16">
           <div className="relative aspect-square bg-neutral-800 overflow-hidden">

--- a/src/data/products.ts
+++ b/src/data/products.ts
@@ -8,21 +8,56 @@ export interface Product {
   features: string[];
 }
 
-export const products: Product[] = [
+interface ContentfulAsset {
+  sys?: {
+    id?: string;
+  };
+  fields?: {
+    file?: {
+      url?: string;
+    };
+  };
+}
+
+interface ContentfulEntry {
+  sys?: {
+    id?: string;
+    contentType?: {
+      sys?: {
+        id?: string;
+      };
+    };
+  };
+  fields?: Record<string, unknown>;
+}
+
+interface ContentfulEntriesResponse {
+  items?: ContentfulEntry[];
+  includes?: {
+    Asset?: ContentfulAsset[];
+  };
+}
+
+const SPACE_ID = 'l19phsq5uz9j';
+const ENVIRONMENT = 'master';
+const ACCESS_TOKEN = 'vk0QVD1KmLlRNZntBIsmow_USIhrRQBy9WGJJWvVjrc';
+
+export const fallbackProducts: Product[] = [
   {
     id: 'precision-putter',
     name: 'Precision Putter',
     price: 249.99,
     image: '/Gemini_Generated_Image_9pmrtr9pmrtr9pmr.png',
     category: 'men',
-    description: 'Engineered for accuracy and control, the Precision Putter features a matte black finish with optimal weight distribution for consistent putting performance.',
+    description:
+      'Engineered for accuracy and control, the Precision Putter features a matte black finish with optimal weight distribution for consistent putting performance.',
     features: [
       'CNC milled face for precise ball control',
       'Premium matte black finish',
       'Optimized weight distribution',
       'Tour-proven design',
-      'Includes premium headcover'
-    ]
+      'Includes premium headcover',
+    ],
   },
   {
     id: 'signature-driver-cover',
@@ -30,14 +65,15 @@ export const products: Product[] = [
     price: 79.99,
     image: '/Gemini_Generated_Image_d1hrxcd1hrxcd1hr.png',
     category: 'men',
-    description: 'Protect your most valuable club with our premium leather driver headcover. Features the iconic Lag Daddy Golf Co logo and superior padding.',
+    description:
+      'Protect your most valuable club with our premium leather driver headcover. Features the iconic Lag Daddy Golf Co logo and superior padding.',
     features: [
       'Premium synthetic leather construction',
       'Plush interior lining',
       'Embroidered Lag Daddy Golf Co logo',
       'Easy on/off magnetic closure',
-      'Water-resistant exterior'
-    ]
+      'Water-resistant exterior',
+    ],
   },
   {
     id: 'tour-stand-bag',
@@ -45,21 +81,338 @@ export const products: Product[] = [
     price: 399.99,
     image: '/Gemini_Generated_Image_wsy8wjwsy8wjwsy8.png',
     category: 'men',
-    description: 'The ultimate golf bag for serious players. Lightweight yet durable with 14-way top divider and premium organizational features.',
+    description:
+      'The ultimate golf bag for serious players. Lightweight yet durable with 14-way top divider and premium organizational features.',
     features: [
       '14-way full-length dividers',
       'Lightweight carbon fiber stand',
       'Multiple insulated pockets',
       'Integrated cart strap system',
-      'Premium waterproof fabric'
-    ]
-  }
+      'Premium waterproof fabric',
+    ],
+  },
 ];
 
-export const getProductById = (id: string): Product | undefined => {
-  return products.find(product => product.id === id);
+let cachedProducts: Product[] | null = null;
+let inFlightRequest: Promise<Product[]> | null = null;
+
+const FALLBACK_CATEGORY: Product['category'] = 'men';
+
+const contentfulEndpoint = `https://cdn.contentful.com/spaces/${SPACE_ID}/environments/${ENVIRONMENT}/entries?access_token=${ACCESS_TOKEN}`;
+
+const ALLOWED_CATEGORIES: Product['category'][] = ['men', 'women', 'kids'];
+
+const slugify = (value: string): string => {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 100);
 };
 
-export const getProductsByCategory = (category: 'men' | 'women' | 'kids'): Product[] => {
-  return products.filter(product => product.category === category);
+const ensureHttpsUrl = (url?: string): string | undefined => {
+  if (!url) {
+    return undefined;
+  }
+
+  if (url.startsWith('http://') || url.startsWith('https://')) {
+    return url;
+  }
+
+  if (url.startsWith('//')) {
+    return `https:${url}`;
+  }
+
+  if (url.startsWith('/')) {
+    return url;
+  }
+
+  return `https://${url}`;
+};
+
+const createAssetMap = (assets: ContentfulAsset[] = []): Map<string, string> => {
+  return assets.reduce((map, asset) => {
+    const id = asset.sys?.id;
+    const url = ensureHttpsUrl(asset.fields?.file?.url);
+
+    if (id && url) {
+      map.set(id, url);
+    }
+
+    return map;
+  }, new Map<string, string>());
+};
+
+const extractRichText = (value: unknown): string => {
+  if (!value) {
+    return '';
+  }
+
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(extractRichText).join(' ');
+  }
+
+  if (typeof value === 'object') {
+    const objectValue = value as { content?: unknown; value?: unknown };
+
+    if (objectValue.value && typeof objectValue.value === 'string') {
+      return objectValue.value;
+    }
+
+    if (objectValue.content) {
+      return extractRichText(objectValue.content);
+    }
+  }
+
+  return '';
+};
+
+const normaliseFeatures = (value: unknown): string[] => {
+  if (!value) {
+    return [];
+  }
+
+  if (Array.isArray(value)) {
+    return value
+      .map((item) => {
+        if (typeof item === 'string') {
+          return item;
+        }
+
+        if (item && typeof item === 'object') {
+          const itemRecord = item as { fields?: Record<string, unknown>; value?: unknown };
+
+          if (typeof itemRecord.value === 'string') {
+            return itemRecord.value;
+          }
+
+          const fields = itemRecord.fields ?? {};
+          const candidate =
+            fields.feature ??
+            fields.text ??
+            fields.title ??
+            fields.name ??
+            fields.label ??
+            fields.copy;
+
+          if (typeof candidate === 'string') {
+            return candidate;
+          }
+        }
+
+        return undefined;
+      })
+      .filter((item): item is string => typeof item === 'string' && item.trim().length > 0)
+      .map((item) => item.trim());
+  }
+
+  if (typeof value === 'string') {
+    return value
+      .split(/\r?\n|\u2022|\*/)
+      .map((item) => item.trim())
+      .filter(Boolean);
+  }
+
+  return [];
+};
+
+const resolveImageUrl = (imageField: unknown, assets: Map<string, string>): string | undefined => {
+  if (!imageField) {
+    return undefined;
+  }
+
+  if (typeof imageField === 'string') {
+    return ensureHttpsUrl(imageField);
+  }
+
+  if (Array.isArray(imageField)) {
+    for (const item of imageField) {
+      const url = resolveImageUrl(item, assets);
+      if (url) {
+        return url;
+      }
+    }
+    return undefined;
+  }
+
+  if (typeof imageField === 'object') {
+    const linkedAsset = imageField as {
+      sys?: { id?: string };
+      fields?: { file?: { url?: string } };
+    };
+
+    const directUrl = ensureHttpsUrl(linkedAsset.fields?.file?.url);
+
+    if (directUrl) {
+      return directUrl;
+    }
+
+    const assetId = linkedAsset.sys?.id;
+    if (assetId && assets.has(assetId)) {
+      return assets.get(assetId);
+    }
+  }
+
+  return undefined;
+};
+
+const normaliseCategory = (value: unknown): Product['category'] => {
+  if (typeof value === 'string') {
+    const normalised = value.trim().toLowerCase();
+
+    if (ALLOWED_CATEGORIES.includes(normalised as Product['category'])) {
+      return normalised as Product['category'];
+    }
+  }
+
+  return FALLBACK_CATEGORY;
+};
+
+const mapEntryToProduct = (
+  entry: ContentfulEntry,
+  assetMap: Map<string, string>
+): Product | null => {
+  const fields = entry.fields ?? {};
+
+  const nameCandidate =
+    fields.name ??
+    fields.title ??
+    fields.productName ??
+    fields.heading ??
+    fields.productTitle;
+
+  if (typeof nameCandidate !== 'string' || nameCandidate.trim().length === 0) {
+    return null;
+  }
+
+  const name = nameCandidate.trim();
+
+  const slugSource =
+    fields.slug ??
+    fields.handle ??
+    fields.identifier ??
+    fields.productSlug ??
+    fields.id ??
+    name ??
+    entry.sys?.id;
+
+  const slug = typeof slugSource === 'string' && slugSource.trim().length > 0
+    ? slugify(slugSource)
+    : slugify(name);
+
+  const rawPrice =
+    fields.price ??
+    fields.msrp ??
+    fields.cost ??
+    fields.productPrice ??
+    fields.basePrice;
+
+  const priceNumber =
+    typeof rawPrice === 'number'
+      ? rawPrice
+      : typeof rawPrice === 'string'
+        ? Number.parseFloat(rawPrice)
+        : NaN;
+
+  const price = Number.isFinite(priceNumber) ? priceNumber : 0;
+
+  const rawDescription =
+    fields.description ??
+    fields.productDescription ??
+    fields.summary ??
+    fields.body ??
+    fields.copy ??
+    fields.seoDescription;
+
+  const descriptionText = extractRichText(rawDescription).trim();
+
+  const description = descriptionText.length > 0
+    ? descriptionText
+    : 'Explore premium golf gear, apparel, and accessories from Lag Daddy Golf Co.';
+
+  const imageField =
+    fields.image ??
+    fields.heroImage ??
+    fields.mainImage ??
+    fields.thumbnail ??
+    fields.featuredImage ??
+    fields.gallery;
+
+  const resolvedImage = resolveImageUrl(imageField, assetMap) ?? fallbackProducts[0]?.image;
+
+  const featuresField =
+    fields.features ??
+    fields.featureList ??
+    fields.productFeatures ??
+    fields.bulletPoints ??
+    fields.highlights ??
+    fields.keyFeatures;
+
+  const features = normaliseFeatures(featuresField);
+
+  const category = normaliseCategory(
+    fields.category ?? fields.collection ?? fields.department ?? fields.gender ?? fields.segment
+  );
+
+  return {
+    id: slug,
+    name,
+    price,
+    image: resolvedImage,
+    category,
+    description,
+    features,
+  };
+};
+
+const fetchProductsFromApi = async (): Promise<Product[]> => {
+  const response = await fetch(contentfulEndpoint);
+
+  if (!response.ok) {
+    throw new Error(`Contentful request failed: ${response.status} ${response.statusText}`);
+  }
+
+  const payload: ContentfulEntriesResponse = await response.json();
+
+  const entries = payload.items ?? [];
+  const assetMap = createAssetMap(payload.includes?.Asset);
+
+  return entries
+    .map((entry) => mapEntryToProduct(entry, assetMap))
+    .filter((product): product is Product => product !== null);
+};
+
+export const fetchProductsFromContentful = async (): Promise<Product[]> => {
+  if (cachedProducts) {
+    return cachedProducts;
+  }
+
+  if (inFlightRequest) {
+    return inFlightRequest;
+  }
+
+  inFlightRequest = fetchProductsFromApi()
+    .then((products) => {
+      cachedProducts = products;
+      inFlightRequest = null;
+
+      return cachedProducts;
+    })
+    .catch((error) => {
+      inFlightRequest = null;
+      throw error;
+    });
+
+  return inFlightRequest;
+};
+
+export const getCachedProducts = (): Product[] | null => cachedProducts;
+
+export const setCachedProducts = (products: Product[]): void => {
+  cachedProducts = products;
 };

--- a/src/hooks/useProducts.ts
+++ b/src/hooks/useProducts.ts
@@ -1,0 +1,83 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { Product } from '../data/products';
+import {
+  fetchProductsFromContentful,
+  fallbackProducts,
+  getCachedProducts,
+  setCachedProducts,
+} from '../data/products';
+
+interface UseProductsResult {
+  products: Product[];
+  isLoading: boolean;
+  error: Error | null;
+}
+
+export const useProducts = (): UseProductsResult => {
+  const [products, setProducts] = useState<Product[]>(() => getCachedProducts() ?? []);
+  const [isLoading, setIsLoading] = useState<boolean>(() => products.length === 0);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    if (products.length > 0) {
+      return () => {
+        isMounted = false;
+      };
+    }
+
+    setIsLoading(true);
+
+    fetchProductsFromContentful()
+      .then((fetchedProducts) => {
+        if (!isMounted) {
+          return;
+        }
+
+        if (fetchedProducts.length === 0) {
+          setProducts(fallbackProducts);
+          setError(null);
+          return;
+        }
+
+        setProducts(fetchedProducts);
+        setCachedProducts(fetchedProducts);
+        setError(null);
+      })
+      .catch((err: unknown) => {
+        if (!isMounted) {
+          return;
+        }
+
+        const errorInstance = err instanceof Error ? err : new Error('Failed to load products from Contentful');
+        setError(errorInstance);
+        setProducts(fallbackProducts);
+      })
+      .finally(() => {
+        if (isMounted) {
+          setIsLoading(false);
+        }
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [products.length]);
+
+  return { products, isLoading, error };
+};
+
+export const useProductById = (id?: string): { product: Product | undefined; isLoading: boolean; error: Error | null } => {
+  const { products, isLoading, error } = useProducts();
+
+  const product = useMemo(() => {
+    if (!id) {
+      return undefined;
+    }
+
+    return products.find((item) => item.id === id);
+  }, [id, products]);
+
+  return { product, isLoading, error };
+};


### PR DESCRIPTION
## Summary
- add a Contentful-backed product loader with normalization, caching, and static fallbacks
- introduce reusable hooks for retrieving products and individual PDP data
- update collection and PDP pages to surface Contentful data with loading and error handling messaging

## Testing
- npm run typecheck *(fails: environment is missing React/DOM type declarations because node modules have not been installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e94611117c8321ae86d93b453f6690