### PR TITLE
Add kids collection page and divot fixer product

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import Header from './components/Header';
 import Home from './components/Home';
 import MensCollection from './components/MensCollection';
+import KidsCollection from './components/KidsCollection';
 import ProductDetail from './components/ProductDetail';
 import ReserveBay from './components/ReserveBay';
 import ReserveBayResults from './components/ReserveBayResults';
@@ -16,7 +17,7 @@ function App() {
           <Route path="/" element={<Home />} />
           <Route path="/collection/men" element={<MensCollection />} />
           <Route path="/collection/women" element={<div className="pt-32 text-center">Women's Collection Coming Soon</div>} />
-          <Route path="/collection/kids" element={<div className="pt-32 text-center">Kids' Collection Coming Soon</div>} />
+          <Route path="/collection/kids" element={<KidsCollection />} />
           <Route path="/product/:id" element={<ProductDetail />} />
           <Route path="/reserve" element={<ReserveBay />} />
           <Route path="/reserve/results" element={<ReserveBayResults />} />

--- a/src/components/KidsCollection.tsx
+++ b/src/components/KidsCollection.tsx
@@ -1,0 +1,103 @@
+import { useMemo } from 'react';
+import { Link } from 'react-router-dom';
+import { useProducts } from '../hooks/useProducts';
+import StructuredData from './StructuredData';
+import { SITE_URL, usePageMetadata } from '../hooks/usePageMetadata';
+
+export default function KidsCollection() {
+  const { products, isLoading, error } = useProducts();
+
+  const kidsProducts = useMemo(
+    () => products.filter((product) => product.category === 'kids'),
+    [products]
+  );
+
+  usePageMetadata({
+    title: "Kids' Golf Collection | Lag Daddy Golf Co",
+    description:
+      'Discover junior-friendly golf gear and accessories from Lag Daddy Golf Co designed to inspire the next generation.',
+    keywords: [
+      "kids' golf collection",
+      'junior golf accessories',
+      'youth golf gear',
+      'Lag Daddy kids lineup',
+    ],
+    canonicalPath: '/collection/kids',
+  });
+
+  const breadcrumbStructuredData = useMemo(
+    () => ({
+      '@context': 'https://schema.org',
+      '@type': 'BreadcrumbList',
+      itemListElement: [
+        {
+          '@type': 'ListItem',
+          position: 1,
+          name: 'Home',
+          item: SITE_URL,
+        },
+        {
+          '@type': 'ListItem',
+          position: 2,
+          name: "Kids' Collection",
+          item: `${SITE_URL}/collection/kids`,
+        },
+      ],
+    }),
+    []
+  );
+
+  return (
+    <div className="min-h-screen bg-neutral-900 text-white pt-32 pb-24 px-6">
+      <div className="container mx-auto">
+        <div className="mb-16">
+          <h1 className="text-5xl md:text-6xl font-light tracking-wider uppercase mb-4">
+            Kids' Collection
+          </h1>
+          <p className="text-xl text-neutral-400 font-light">
+            Golf essentials sized for future champions
+          </p>
+        </div>
+
+        {isLoading ? (
+          <div className="text-neutral-400 font-light">Loading products...</div>
+        ) : error ? (
+          <div className="text-rose-400 font-light">
+            Unable to load products from Contentful. Displaying available inventory.
+          </div>
+        ) : null}
+
+        {kidsProducts.length > 0 ? (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 mt-8">
+            {kidsProducts.map((product) => (
+              <Link key={product.id} to={`/product/${product.id}`} className="group">
+                <div className="relative overflow-hidden bg-neutral-800 aspect-square mb-4">
+                  <img
+                    src={product.image}
+                    alt={product.name}
+                    className="w-full h-full object-cover group-hover:scale-110 transition-transform duration-700"
+                  />
+                  <div className="absolute inset-0 bg-black/0 group-hover:bg-black/20 transition-colors duration-300" />
+                </div>
+                <div className="space-y-2">
+                  <h3 className="text-2xl font-light tracking-wide group-hover:text-neutral-300 transition-colors">
+                    {product.name}
+                  </h3>
+                  <p className="text-xl font-light text-neutral-400">${product.price.toFixed(2)}</p>
+                </div>
+              </Link>
+            ))}
+          </div>
+        ) : (
+          !isLoading && (
+            <div className="text-neutral-400 font-light mt-8">
+              No products available in this collection right now.
+            </div>
+          )
+        )}
+      </div>
+
+      <StructuredData id="kids-breadcrumbs" data={breadcrumbStructuredData} />
+    </div>
+  );
+}

--- a/src/components/ProductDetail.tsx
+++ b/src/components/ProductDetail.tsx
@@ -10,6 +10,15 @@ export default function ProductDetail() {
   const { product, isLoading, error } = useProductById(id);
   const [addedToCart, setAddedToCart] = useState(false);
 
+  const category = product?.category ?? 'men';
+  const categoryNameMap: Record<'men' | 'women' | 'kids', string> = {
+    men: "Men's",
+    women: "Women's",
+    kids: "Kids'",
+  };
+  const categoryName = categoryNameMap[category];
+  const categoryPath = `/collection/${category}`;
+
   const productTitle = product
     ? `${product.name} | Lag Daddy Golf Co`
     : 'Product Not Found | Lag Daddy Golf Co';
@@ -63,30 +72,33 @@ export default function ProductDetail() {
     };
   }, [product]);
 
-  const breadcrumbStructuredData = useMemo(() => ({
-    '@context': 'https://schema.org',
-    '@type': 'BreadcrumbList',
-    itemListElement: [
-      {
-        '@type': 'ListItem',
-        position: 1,
-        name: 'Home',
-        item: SITE_URL,
-      },
-      {
-        '@type': 'ListItem',
-        position: 2,
-        name: "Men's Collection",
-        item: `${SITE_URL}/collection/men`,
-      },
-      {
-        '@type': 'ListItem',
-        position: 3,
-        name: product ? product.name : 'Product',
-        item: product ? `${SITE_URL}/product/${product.id}` : `${SITE_URL}/collection/men`,
-      },
-    ],
-  }), [product]);
+  const breadcrumbStructuredData = useMemo(
+    () => ({
+      '@context': 'https://schema.org',
+      '@type': 'BreadcrumbList',
+      itemListElement: [
+        {
+          '@type': 'ListItem',
+          position: 1,
+          name: 'Home',
+          item: SITE_URL,
+        },
+        {
+          '@type': 'ListItem',
+          position: 2,
+          name: `${categoryName} Collection`,
+          item: `${SITE_URL}${categoryPath}`,
+        },
+        {
+          '@type': 'ListItem',
+          position: 3,
+          name: product ? product.name : 'Product',
+          item: product ? `${SITE_URL}/product/${product.id}` : `${SITE_URL}${categoryPath}`,
+        },
+      ],
+    }),
+    [categoryName, categoryPath, product]
+  );
 
   if (isLoading) {
     return (
@@ -107,7 +119,7 @@ export default function ProductDetail() {
         <div className="container mx-auto text-center">
           <h1 className="text-4xl font-light mb-8">Product Not Found</h1>
           <Link
-            to="/collection/men"
+            to={categoryPath}
             className="inline-flex items-center gap-2 text-neutral-400 hover:text-white transition-colors"
           >
             <ArrowLeft size={20} />
@@ -127,11 +139,11 @@ export default function ProductDetail() {
     <div className="min-h-screen bg-neutral-900 text-white pt-32 pb-24 px-6">
       <div className="container mx-auto">
         <Link
-          to="/collection/men"
+          to={categoryPath}
           className="inline-flex items-center gap-2 text-neutral-400 hover:text-white transition-colors mb-12 font-light"
         >
           <ArrowLeft size={20} />
-          Back to Men's Collection
+          Back to {categoryName} Collection
         </Link>
 
         {error && (

--- a/src/data/products.ts
+++ b/src/data/products.ts
@@ -91,6 +91,22 @@ export const fallbackProducts: Product[] = [
       'Premium waterproof fabric',
     ],
   },
+  {
+    id: 'lag-daddy-divot-fixer',
+    name: 'Lag Daddy Divot Fixer',
+    price: 34.99,
+    image: '/Gemini_Generated_Image_baz6ilbaz6ilbaz6.png',
+    category: 'kids',
+    description:
+      'Compact and ergonomic, the Lag Daddy Divot Fixer helps junior players repair greens with ease while showcasing the signature monogram.',
+    features: [
+      'Lightweight aircraft-grade aluminum construction',
+      'Dual-prong design for effortless divot repair',
+      'Integrated magnetic ball marker with Lag Daddy crest',
+      'Soft-touch grip sized for junior golfers',
+      'Course-approved accessory for growing players',
+    ],
+  },
 ];
 
 let cachedProducts: Product[] | null = null;


### PR DESCRIPTION
## Summary
- add a dedicated kids collection PLP that reuses the Contentful-powered product feed
- add a fallback Lag Daddy Divot Fixer product under the kids category
- update product detail breadcrumbs and navigation to respect the product’s category

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js' from eslint.config.js on this Node version)*
- npm run typecheck *(fails: TypeScript cannot find many dependency type definitions in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fa7ba8a3a08321a821dea97264b728