### PR TITLE
Use product photo field for images

### DIFF
--- a/src/components/MensCollection.tsx
+++ b/src/components/MensCollection.tsx
@@ -77,7 +77,7 @@ export default function MensCollection() {
               >
                 <div className="relative overflow-hidden bg-neutral-800 aspect-square mb-4">
                   <img
-                    src={product.image}
+                    src={product.photo}
                     alt={product.name}
                     className="w-full h-full object-cover group-hover:scale-110 transition-transform duration-700"
                   />

--- a/src/components/ProductDetail.tsx
+++ b/src/components/ProductDetail.tsx
@@ -2,13 +2,32 @@ import { useState, useMemo } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { ArrowLeft, ShoppingCart, Check } from 'lucide-react';
 import StructuredData from './StructuredData';
-import { SITE_URL, usePageMetadata } from '../hooks/usePageMetadata';
+import { SITE_URL, DEFAULT_SOCIAL_IMAGE, usePageMetadata } from '../hooks/usePageMetadata';
 import { useProductById } from '../hooks/useProducts';
 
 export default function ProductDetail() {
   const { id } = useParams<{ id: string }>();
   const { product, isLoading, error } = useProductById(id);
   const [addedToCart, setAddedToCart] = useState(false);
+
+  const resolveProductImageUrl = (photo?: string): string | undefined => {
+    if (!photo) {
+      return undefined;
+    }
+
+    if (/^https?:\/\//i.test(photo)) {
+      return photo;
+    }
+
+    if (photo.startsWith('//')) {
+      return `https:${photo}`;
+    }
+
+    const normalisedPath = photo.startsWith('/') ? photo : `/${photo}`;
+    return `${SITE_URL}${normalisedPath}`;
+  };
+
+  const productImageUrl = resolveProductImageUrl(product?.photo);
 
   const productTitle = product
     ? `${product.name} | Lag Daddy Golf Co`
@@ -34,7 +53,7 @@ export default function ProductDetail() {
     canonicalPath,
     openGraph: {
       type: 'product',
-      image: product ? `${SITE_URL}${product.photo}` : undefined,
+      image: productImageUrl,
     },
   });
 
@@ -48,7 +67,7 @@ export default function ProductDetail() {
       '@type': 'Product',
       name: product.name,
       description: product.description,
-      image: `${SITE_URL}${product.photo}`,
+      image: productImageUrl ?? DEFAULT_SOCIAL_IMAGE,
       offers: {
         '@type': 'Offer',
         priceCurrency: 'USD',
@@ -61,7 +80,7 @@ export default function ProductDetail() {
         name: 'Lag Daddy Golf Co',
       },
     };
-  }, [product]);
+  }, [product, productImageUrl]);
 
   const breadcrumbStructuredData = useMemo(() => ({
     '@context': 'https://schema.org',

--- a/src/components/ProductDetail.tsx
+++ b/src/components/ProductDetail.tsx
@@ -34,7 +34,7 @@ export default function ProductDetail() {
     canonicalPath,
     openGraph: {
       type: 'product',
-      image: product ? `${SITE_URL}${product.image}` : undefined,
+      image: product ? `${SITE_URL}${product.photo}` : undefined,
     },
   });
 
@@ -48,7 +48,7 @@ export default function ProductDetail() {
       '@type': 'Product',
       name: product.name,
       description: product.description,
-      image: `${SITE_URL}${product.image}`,
+      image: `${SITE_URL}${product.photo}`,
       offers: {
         '@type': 'Offer',
         priceCurrency: 'USD',
@@ -143,7 +143,7 @@ export default function ProductDetail() {
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-16">
           <div className="relative aspect-square bg-neutral-800 overflow-hidden">
             <img
-              src={product.image}
+              src={product.photo}
               alt={product.name}
               className="w-full h-full object-cover"
             />

--- a/src/data/products.ts
+++ b/src/data/products.ts
@@ -2,7 +2,7 @@ export interface Product {
   id: string;
   name: string;
   price: number;
-  image: string;
+  photo: string;
   category: 'men' | 'women' | 'kids';
   description: string;
   features: string[];
@@ -47,7 +47,7 @@ export const fallbackProducts: Product[] = [
     id: 'precision-putter',
     name: 'Precision Putter',
     price: 249.99,
-    image: '/Gemini_Generated_Image_9pmrtr9pmrtr9pmr.png',
+    photo: '/Gemini_Generated_Image_9pmrtr9pmrtr9pmr.png',
     category: 'men',
     description:
       'Engineered for accuracy and control, the Precision Putter features a matte black finish with optimal weight distribution for consistent putting performance.',
@@ -63,7 +63,7 @@ export const fallbackProducts: Product[] = [
     id: 'signature-driver-cover',
     name: 'Signature Driver Cover',
     price: 79.99,
-    image: '/Gemini_Generated_Image_d1hrxcd1hrxcd1hr.png',
+    photo: '/Gemini_Generated_Image_d1hrxcd1hrxcd1hr.png',
     category: 'men',
     description:
       'Protect your most valuable club with our premium leather driver headcover. Features the iconic Lag Daddy Golf Co logo and superior padding.',
@@ -79,7 +79,7 @@ export const fallbackProducts: Product[] = [
     id: 'tour-stand-bag',
     name: 'Tour Stand Bag',
     price: 399.99,
-    image: '/Gemini_Generated_Image_wsy8wjwsy8wjwsy8.png',
+    photo: '/Gemini_Generated_Image_wsy8wjwsy8wjwsy8.png',
     category: 'men',
     description:
       'The ultimate golf bag for serious players. Lightweight yet durable with 14-way top divider and premium organizational features.',
@@ -336,6 +336,7 @@ const mapEntryToProduct = (
     : 'Explore premium golf gear, apparel, and accessories from Lag Daddy Golf Co.';
 
   const imageField =
+    fields.photo ??
     fields.image ??
     fields.heroImage ??
     fields.mainImage ??
@@ -343,7 +344,7 @@ const mapEntryToProduct = (
     fields.featuredImage ??
     fields.gallery;
 
-  const resolvedImage = resolveImageUrl(imageField, assetMap) ?? fallbackProducts[0]?.image;
+  const resolvedPhoto = resolveImageUrl(imageField, assetMap) ?? fallbackProducts[0]?.photo;
 
   const featuresField =
     fields.features ??
@@ -363,7 +364,7 @@ const mapEntryToProduct = (
     id: slug,
     name,
     price,
-    image: resolvedImage,
+    photo: resolvedPhoto,
     category,
     description,
     features,


### PR DESCRIPTION
## Summary
- add support for the `photo` field in the product data model and fallback inventory
- update product detail metadata and markup to reference the photo asset
- render men’s collection product cards with the photo field from Contentful

## Testing
- npm run typecheck *(fails: project dependencies unavailable due to registry access restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68fa890245c88321af3f748614ab4943